### PR TITLE
style: run format after editorconfig

### DIFF
--- a/lua/ohne-accidents.lua
+++ b/lua/ohne-accidents.lua
@@ -3,66 +3,72 @@
 local M = {}
 
 M.config = {
-  welcomeOnStartup = true
+    welcomeOnStartup = true,
 }
 
 function M.setConfig(opts)
-  for k, v in pairs(opts) do
-    if M.config[k] ~= nil then
-      M.config[k] = v
+    for k, v in pairs(opts) do
+        if M.config[k] ~= nil then
+            M.config[k] = v
+        end
     end
-  end
 end
 
 -- Calculates the time since last modification of any config file
 local function timeSinceLastChange()
-  local config_dir = vim.fn.stdpath("config")
-  local files = vim.fn.split(vim.fn.glob(config_dir .. "/**/*.lua"), "\n")
+    local config_dir = vim.fn.stdpath("config")
+    local files = vim.fn.split(vim.fn.glob(config_dir .. "/**/*.lua"), "\n")
 
-  local last_modified = 0
-  local current_time = os.time()
+    local last_modified = 0
+    local current_time = os.time()
 
-  for _, file in pairs(files) do
-    local modified_time = vim.fn.getftime(file)
-    last_modified = modified_time > last_modified and modified_time or last_modified
-  end
+    for _, file in pairs(files) do
+        local modified_time = vim.fn.getftime(file)
+        last_modified = modified_time > last_modified and modified_time or last_modified
+    end
 
-  local diff_seconds = os.difftime(current_time, last_modified)
-  local days = vim.fn.floor(diff_seconds / 86400)
-  local hours = vim.fn.floor((diff_seconds % 86400) / 3600)
-  local minutes = vim.fn.floor((diff_seconds % 3600) / 60)
-  local seconds = vim.fn.floor(diff_seconds % 60)
+    local diff_seconds = os.difftime(current_time, last_modified)
+    local days = vim.fn.floor(diff_seconds / 86400)
+    local hours = vim.fn.floor((diff_seconds % 86400) / 3600)
+    local minutes = vim.fn.floor((diff_seconds % 3600) / 60)
+    local seconds = vim.fn.floor(diff_seconds % 60)
 
-  return days, hours, minutes, seconds
+    return days, hours, minutes, seconds
 end
 
 function M.welcomeOnStartup()
-  if not M.config.welcomeOnStartup then
-    return
-  end
+    if not M.config.welcomeOnStartup then
+        return
+    end
 
-  local days = timeSinceLastChange()
-  local message = string.format("╔════╗\n║ %2d ║ Days Without Editing the Configuration\n╚════╝", days)
-  vim.api.nvim_echo({ { message, "Title" } }, true, {})
+    local days = timeSinceLastChange()
+    local message = string.format(
+        "╔════╗\n║ %2d ║ Days Without Editing the Configuration\n╚════╝",
+        days
+    )
+    vim.api.nvim_echo({ { message, "Title" } }, true, {})
 end
 
 function M.displayDetailedMessage()
-  local days, hours, minutes, seconds = timeSinceLastChange()
-  local message = string.format(
-    "╔════╗\n║ %2d ║ Days\n║ %2d ║ Hours\n║ %2d ║ Minutes\n║ %2d ║ Seconds\n╚════╝ Without Editing the Configuration",
-    days,
-    hours, minutes, seconds)
-  vim.api.nvim_echo({ { message, "Title" } }, true, {})
+    local days, hours, minutes, seconds = timeSinceLastChange()
+    local message = string.format(
+        "╔════╗\n║ %2d ║ Days\n║ %2d ║ Hours\n║ %2d ║ Minutes\n║ %2d ║ Seconds\n╚════╝ Without Editing the Configuration",
+        days,
+        hours,
+        minutes,
+        seconds
+    )
+    vim.api.nvim_echo({ { message, "Title" } }, true, {})
 end
 
 function M.setup(opts)
-  if opts then
-    M.setConfig(opts)
-  end
+    if opts then
+        M.setConfig(opts)
+    end
 
-  M.welcomeOnStartup()
+    M.welcomeOnStartup()
 
-  vim.api.nvim_command('command! OhneAccidents lua require("ohne-accidents").displayDetailedMessage()')
+    vim.api.nvim_command('command! OhneAccidents lua require("ohne-accidents").displayDetailedMessage()')
 end
 
 return M

--- a/lua/tests/ohne-accidents_spec.lua
+++ b/lua/tests/ohne-accidents_spec.lua
@@ -1,104 +1,139 @@
 -- ohne-accidents_spec.lua
 
 -- Get the directory of the current script
-local script_dir = debug.getinfo(1, 'S').source:match("@(.*/)")
+local script_dir = debug.getinfo(1, "S").source:match("@(.*/)")
 -- Add the parent directory to package.path
 package.path = package.path .. ";" .. script_dir .. "../?.lua"
 -- Now require the module by name
-local ohne_accidents = require 'ohne-accidents'
+local ohne_accidents = require("ohne-accidents")
 
-describe('ohne-accidents', function()
+describe("ohne-accidents", function()
+    before_each(function()
+        ohne_accidents.setConfig({ welcomeOnStartup = false })
+    end)
 
-  before_each(function()
-    ohne_accidents.setConfig({ welcomeOnStartup = false })
-  end)
-
-  local mock_vim = {
-    fn = {
-      expand = function() return "/home/user/.config/nvim" end,
-      split = function() return { "file1.lua", "file2.lua" } end,
-      glob = function() return "file1.lua\nfile2.lua" end,
-      getftime = function() return 1628000000 end,               -- Mocked file modification time
-      floor = function(x) return math.floor(x) end,
-      stdpath = function() return "/home/user/.config/nvim" end, -- Mocked stdpath function
-    },
-    api = {
-      nvim_echo = function() end,
+    local mock_vim = {
+        fn = {
+            expand = function()
+                return "/home/user/.config/nvim"
+            end,
+            split = function()
+                return { "file1.lua", "file2.lua" }
+            end,
+            glob = function()
+                return "file1.lua\nfile2.lua"
+            end,
+            getftime = function()
+                return 1628000000
+            end, -- Mocked file modification time
+            floor = function(x)
+                return math.floor(x)
+            end,
+            stdpath = function()
+                return "/home/user/.config/nvim"
+            end, -- Mocked stdpath function
+        },
+        api = {
+            nvim_echo = function() end,
+        },
     }
-  }
 
-  -- Mock os.time to return the same value as getftime
-  local original_os_time = os.time
-  os.time = function() return 1628000000 end
+    -- Mock os.time to return the same value as getftime
+    local original_os_time = os.time
+    os.time = function()
+        return 1628000000
+    end
 
-  setup(function()
-    _G.vim = mock_vim
-  end)
+    setup(function()
+        _G.vim = mock_vim
+    end)
 
-  teardown(function()
-    os.time = original_os_time
-  end)
+    teardown(function()
+        os.time = original_os_time
+    end)
 
-  it('displays welcome message', function()
-    -- Set the welcomeOnStartup configuration option to true
-    ohne_accidents.setConfig({ welcomeOnStartup = true })
+    it("displays welcome message", function()
+        -- Set the welcomeOnStartup configuration option to true
+        ohne_accidents.setConfig({ welcomeOnStartup = true })
 
-    local spy = require('luassert.spy')
-    local nvim_echo_spy = spy.on(vim.api, 'nvim_echo')
+        local spy = require("luassert.spy")
+        local nvim_echo_spy = spy.on(vim.api, "nvim_echo")
 
-    ohne_accidents.welcomeOnStartup()
+        ohne_accidents.welcomeOnStartup()
 
-    assert.spy(nvim_echo_spy).was.called_with(
-      { { "╔════╗\n║  0 ║ Days Without Editing the Configuration\n╚════╝", "Title" } }, true, {})
-  end)
+        assert.spy(nvim_echo_spy).was.called_with(
+            { { "╔════╗\n║  0 ║ Days Without Editing the Configuration\n╚════╝", "Title" } },
+            true,
+            {}
+        )
+    end)
 
-  it('displays welcome message with 33 days', function()
-    -- Adjust os.time to return a value that is 33 days later than getftime
-    os.time = function() return 1628000000 + 33 * 86400 end
+    it("displays welcome message with 33 days", function()
+        -- Adjust os.time to return a value that is 33 days later than getftime
+        os.time = function()
+            return 1628000000 + 33 * 86400
+        end
 
-    -- Set the welcomeOnStartup configuration option to true
-    ohne_accidents.setConfig({ welcomeOnStartup = true })
+        -- Set the welcomeOnStartup configuration option to true
+        ohne_accidents.setConfig({ welcomeOnStartup = true })
 
-    local spy = require('luassert.spy')
-    local nvim_echo_spy = spy.on(vim.api, 'nvim_echo')
+        local spy = require("luassert.spy")
+        local nvim_echo_spy = spy.on(vim.api, "nvim_echo")
 
-    ohne_accidents.welcomeOnStartup()
+        ohne_accidents.welcomeOnStartup()
 
-    assert.spy(nvim_echo_spy).was.called_with(
-      { { "╔════╗\n║ 33 ║ Days Without Editing the Configuration\n╚════╝", "Title" } }, true, {})
-  end)
+        assert.spy(nvim_echo_spy).was.called_with(
+            { { "╔════╗\n║ 33 ║ Days Without Editing the Configuration\n╚════╝", "Title" } },
+            true,
+            {}
+        )
+    end)
 
-  it('displays detailed message', function()
-    -- Adjust os.time to return a value that is 33 days, 7 hours, 46 minutes, and 40 seconds later than getftime
-    os.time = function() return 1628000000 + 33 * 86400 + 7 * 3600 + 46 * 60 + 40 end
+    it("displays detailed message", function()
+        -- Adjust os.time to return a value that is 33 days, 7 hours, 46 minutes, and 40 seconds later than getftime
+        os.time = function()
+            return 1628000000 + 33 * 86400 + 7 * 3600 + 46 * 60 + 40
+        end
 
-    local spy = require('luassert.spy')
-    local nvim_echo_spy = spy.on(vim.api, 'nvim_echo')
+        local spy = require("luassert.spy")
+        local nvim_echo_spy = spy.on(vim.api, "nvim_echo")
 
-    ohne_accidents.displayDetailedMessage()
+        ohne_accidents.displayDetailedMessage()
 
-    assert.spy(nvim_echo_spy).was.called_with(
-      { { "╔════╗\n║ 33 ║ Days\n║  7 ║ Hours\n║ 46 ║ Minutes\n║ 40 ║ Seconds\n╚════╝ Without Editing the Configuration", "Title" } },
-      true, {})
-  end)
+        assert.spy(nvim_echo_spy).was.called_with(
+            {
+                {
+                    "╔════╗\n║ 33 ║ Days\n║  7 ║ Hours\n║ 46 ║ Minutes\n║ 40 ║ Seconds\n╚════╝ Without Editing the Configuration",
+                    "Title",
+                },
+            },
+            true,
+            {}
+        )
+    end)
 
-  it('displays welcome message on startup', function()
-    -- Reset os.time to return the same value as getftime
-    os.time = function() return 1628000000 end
+    it("displays welcome message on startup", function()
+        -- Reset os.time to return the same value as getftime
+        os.time = function()
+            return 1628000000
+        end
 
-    -- Set the welcomeOnStartup configuration option to true
-    ohne_accidents.setConfig({ welcomeOnStartup = true })
+        -- Set the welcomeOnStartup configuration option to true
+        ohne_accidents.setConfig({ welcomeOnStartup = true })
 
-    local spy = require('luassert.spy')
-    local nvim_echo_spy = spy.on(vim.api, 'nvim_echo')
+        local spy = require("luassert.spy")
+        local nvim_echo_spy = spy.on(vim.api, "nvim_echo")
 
-    ohne_accidents.welcomeOnStartup()
+        ohne_accidents.welcomeOnStartup()
 
-    assert.spy(nvim_echo_spy).was.called_with(
-      { { "╔════╗\n║  0 ║ Days Without Editing the Configuration\n╚════╝", "Title" } }, true, {})
-  end)
+        assert.spy(nvim_echo_spy).was.called_with(
+            { { "╔════╗\n║  0 ║ Days Without Editing the Configuration\n╚════╝", "Title" } },
+            true,
+            {}
+        )
+    end)
 
-  it('welcomeOnStartup is false by default', function()
-    assert.is_false(ohne_accidents.config.welcomeOnStartup)
-  end)
+    it("welcomeOnStartup is false by default", function()
+        assert.is_false(ohne_accidents.config.welcomeOnStartup)
+    end)
 end)


### PR DESCRIPTION
Hey there, 

I want to try to implement #3. 
I noticed that you added a `.editorconfig`(4eb565a5fc3686dde92b32ab38eeffe8911e8dcb), but you didn't ran a formater with it. So as a precursor to #3, I ran `stylua .` formater for the project and this is the result. I will base my PR for #3  on this PR. 

> The diff is huge, but the contents didn't change. Its just the formatter applying the rules of the `.editorconfig`.

