### PR TITLE
feat(options): add `useLastCommit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2] - 2024-02-06
+
+- Support for using the last commit as the indicator of the last change. (`config.useLastCommit`)
+
 ## [0.1.1] - 2024-31-05
 
 ### Added
-- Support for notify api.
-- Option to toggle multiline.
+- Support for notify api. (`config.api`)
+- Option to toggle multiline. (`config.multiLine`)
 - Tests for notify api and multiline
 
 ## [0.1.0] - 2024-29-03

--- a/lua/ohne-accidents.lua
+++ b/lua/ohne-accidents.lua
@@ -4,11 +4,12 @@ local M = {}
 ---@field welcomeOnStartup? boolean Choose whether to display the welcome message on startup.
 ---@field multiLine? boolean Choose wether the message should be displayed in a single line or multiple lines.
 ---@field api? "echo" | "notify" Choose whether to use `echo` or `vim.notify` to display the message.
-
+---@field useLastCommit? boolean Use the date of the last commit as the indicator for the time of last changes.
 M.config = {
     welcomeOnStartup = true,
     multiLine = true,
     api = "echo",
+    useLastCommit = false,
 }
 
 function M.setConfig(opts)
@@ -29,19 +30,35 @@ function M.notify(message)
     end
 end
 
--- Calculates the time since last modification of any config file
+-- Get the last commit date in Unix timestamp format
+local function getLastCommitDate()
+    local handle = io.popen("git -C " .. vim.fn.stdpath("config") .. " log -1 --format=%ct")
+    if not handle then
+        return 0
+    else
+        local result = handle:read("*a")
+        handle:close()
+        return tonumber(result)
+    end
+end
+
+-- Calculates the time since the last modification or the last commit date
 local function timeSinceLastChange()
-    local config_dir = vim.fn.stdpath("config")
-    local files = vim.fn.split(vim.fn.glob(config_dir .. "/**/*.lua"), "\n")
-
     local last_modified = 0
-    local current_time = os.time()
 
-    for _, file in pairs(files) do
-        local modified_time = vim.fn.getftime(file)
-        last_modified = modified_time > last_modified and modified_time or last_modified
+    if M.config.useLastCommit then
+        last_modified = getLastCommitDate()
+    else
+        local config_dir = vim.fn.stdpath("config")
+        local files = vim.fn.split(vim.fn.glob(config_dir .. "/**/*.lua"), "\n")
+
+        for _, file in pairs(files) do
+            local modified_time = vim.fn.getftime(file)
+            last_modified = modified_time > last_modified and modified_time or last_modified
+        end
     end
 
+    local current_time = os.time()
     local diff_seconds = os.difftime(current_time, last_modified)
     local days = vim.fn.floor(diff_seconds / 86400)
     local hours = vim.fn.floor((diff_seconds % 86400) / 3600)
@@ -57,15 +74,14 @@ function M.welcomeOnStartup()
     end
 
     local days = timeSinceLastChange()
+    local message_template = M.config.useLastCommit and "Days Since Last Commit"
+        or "Days Without Editing the Configuration"
 
     if M.config.multiLine then
-        local message = string.format(
-            "╔════╗\n║ %2d ║ Days Without Editing the Configuration\n╚════╝",
-            days
-        )
+        local message = string.format("╔════╗\n║ %2d ║ %s\n╚════╝", days, message_template)
         M.notify(message)
     else
-        local message = string.format("%2d Days Without Editing the Configuration", days)
+        local message = string.format("%2d %s", days, message_template)
 
         M.notify(message)
     end
@@ -73,24 +89,27 @@ end
 
 function M.displayDetailedMessage()
     local days, hours, minutes, seconds = timeSinceLastChange()
+    local message_template = M.config.useLastCommit and "Since Last Commit" or "Without Editing the Configuration"
 
     if M.config.multiLine then
         local message = string.format(
-            "╔════╗\n║ %2d ║ Days\n║ %2d ║ Hours\n║ %2d ║ Minutes\n║ %2d ║ Seconds\n╚════╝ Without Editing the Configuration",
+            "╔════╗\n║ %2d ║ Days\n║ %2d ║ Hours\n║ %2d ║ Minutes\n║ %2d ║ Seconds\n╚════╝ %s",
             days,
             hours,
             minutes,
-            seconds
+            seconds,
+            message_template
         )
 
         M.notify(message)
     else
         local message = string.format(
-            "%2d Days, %2d Hours, %2d Minutes, %2d Seconds Without Editing the Configuration.",
+            "%2d Days, %2d Hours, %2d Minutes, %2d Seconds %s.",
             days,
             hours,
             minutes,
-            seconds
+            seconds,
+            message_template
         )
 
         M.notify(message)

--- a/readme.md
+++ b/readme.md
@@ -41,10 +41,12 @@ This is the default configuration, and their description:
 ---@field welcomeOnStartup? boolean Choose whether to display the welcome message on startup.
 ---@field multiLine? boolean Choose wether the message should be displayed in a single line or multiple lines.
 ---@field api? "echo" | "notify" Choose whether to use `echo` or `vim.notify` to display the message.
+---@field useLastCommit? boolean Use the date of the last commit as the indicator for the time of last changes.
 M.config = {
     welcomeOnStartup = true,
     multiLine = true,
     api = "echo",
+    useLastCommit = false,
 }
 ```
 
@@ -104,7 +106,9 @@ Look at the installation example above to see where to put the keybinding.
 
 ### Alternatives
 
--   [ConfigPulse](https://github.com/mrquantumcodes/configpulse)
--   [NvimDaysWithout](https://github.com/idanarye/nvim-days-without)
+Each of these works just a little bit differently than ohne-accidents.
 
-Each of these works just a little bit differently than ohne-accidents. NvimDaysWithout uses git to calculate things. ConfigPulse uses the config folder but doesn't display a welcome message when you open nvim.
+-   [ConfigPulse](https://github.com/mrquantumcodes/configpulse)
+    -   ConfigPulse uses the config folder but doesn't display a welcome message when you open nvim.
+-   [NvimDaysWithout](https://github.com/idanarye/nvim-days-without)
+    -   NvimDaysWithout uses git to calculate things (But this plugin does also has an option for that `config.useLastCommit`).


### PR DESCRIPTION
## What this PR does
- Adds `useLastCommit` as a config option, to use the date of the last commit as indicator for the last change to the Neovim config

## Tests

Once again, I didn't know how to do that. It would be great if you can add a section in the README how to run the tests.

You can add a commit with tests to this PR if you like.
